### PR TITLE
add name for X-Idempotency-Key

### DIFF
--- a/fern/api/definition/payments.yml
+++ b/fern/api/definition/payments.yml
@@ -10,7 +10,9 @@ services:
       base-path: /payments
       auth: true
       headers:
-        X-Idempotency-Key: optional<string>
+        X-Idempotency-Key: 
+          type: optional<string>
+          name: idempotencyKey
       endpoints:
         search:
           docs: |


### PR DESCRIPTION
The field name for `X-Idempotency-Key` is codegenned as `xIdempotencyKey`. It would be more idiomatic to generate `idempotencyKey` instead. 